### PR TITLE
Use transients api

### DIFF
--- a/misha-update-checker.php
+++ b/misha-update-checker.php
@@ -28,7 +28,7 @@ if( ! class_exists( 'mishaUpdateChecker' ) ) {
 			$this->plugin_slug = plugin_basename( __DIR__ );
 			$this->version = '1.0';
 			$this->cache_key = 'misha_custom_upd';
-			$this->cache_allowed = false;
+			$this->cache_allowed = true;
 
 			add_filter( 'plugins_api', array( $this, 'info' ), 20, 3 );
 			add_filter( 'site_transient_update_plugins', array( $this, 'update' ) );
@@ -72,9 +72,6 @@ if( ! class_exists( 'mishaUpdateChecker' ) ) {
 
 
 		function info( $res, $action, $args ) {
-
-			// print_r( $action );
-			// print_r( $args );
 
 			// do nothing if you're not getting plugin information right now
 			if( 'plugin_information' !== $action ) {


### PR DESCRIPTION
Changes cache_allowed from false to true so that people using this code as a template will make use of the transient api. This change also removes two lines of commented out print_r($var) that were presumably for debugging.